### PR TITLE
Add ShouldSendCoT Bool to Cot Interface and Actors

### DIFF
--- a/Source/TAKGM/Private/Cot/CotActor.cpp
+++ b/Source/TAKGM/Private/Cot/CotActor.cpp
@@ -19,6 +19,7 @@ ACotActor::ACotActor()
 	Ce = 1.0f;
 	Le = 0.0f;
 	isStale = false;
+	ShouldSendCoT = true;
 
 	singletonUDPSender = (AUDPSender *) UGameplayStatics::GetActorOfClass(GetWorld(),
 		AUDPSender::StaticClass());
@@ -97,6 +98,11 @@ AUDPSender* ACotActor::GetUDPSender_Implementation()
 	return singletonUDPSender;
 }
 
+bool ACotActor::GetShouldSendCoT_Implementation()
+{
+	return ShouldSendCoT;
+}
+
 void ACotActor::SetType_Implementation(FString& NewType)
 {
 	Type = NewType;
@@ -140,4 +146,9 @@ void ACotActor::SetLe_Implementation(float NewLe)
 void ACotActor::SetUDPSender_Implementation(AUDPSender* UdpSender)
 {
 	singletonUDPSender = UdpSender;
+}
+
+void ACotActor::SetShouldSendCoT_Implementation(bool NewShouldSendCoT)
+{
+	ShouldSendCoT = NewShouldSendCoT;
 }

--- a/Source/TAKGM/Private/Cot/CotCharacter.cpp
+++ b/Source/TAKGM/Private/Cot/CotCharacter.cpp
@@ -19,6 +19,7 @@ ACotCharacter::ACotCharacter()
 	Ce = 1.0f;
 	Le = 0.0f; 
 	isStale = false;
+	ShouldSendCoT = true;
 
 	singletonUDPSender = (AUDPSender*)UGameplayStatics::GetActorOfClass(GetWorld(),
 		AUDPSender::StaticClass());
@@ -104,6 +105,11 @@ AUDPSender* ACotCharacter::GetUDPSender_Implementation()
 	return singletonUDPSender;
 }
 
+bool ACotCharacter::GetShouldSendCoT_Implementation()
+{
+	return ShouldSendCoT;
+}
+
 void ACotCharacter::SetType_Implementation(FString& NewType)
 {
 	Type = NewType;
@@ -147,4 +153,9 @@ void ACotCharacter::SetLe_Implementation(float NewLe)
 void ACotCharacter::SetUDPSender_Implementation(AUDPSender* UdpSender)
 {
 	singletonUDPSender = UdpSender;
+}
+
+void ACotCharacter::SetShouldSendCoT_Implementation(bool NewShouldSendCoT)
+{
+	ShouldSendCoT = NewShouldSendCoT;
 }

--- a/Source/TAKGM/Private/Cot/CotPawn.cpp
+++ b/Source/TAKGM/Private/Cot/CotPawn.cpp
@@ -19,6 +19,7 @@ ACotPawn::ACotPawn()
 	Ce = 1.0f;
 	Le = 0.0f;
 	isStale = false;
+	ShouldSendCoT = true;
 
 	singletonUDPSender = (AUDPSender*)UGameplayStatics::GetActorOfClass(GetWorld(),
 		AUDPSender::StaticClass());
@@ -103,6 +104,11 @@ AUDPSender* ACotPawn::GetUDPSender_Implementation()
 	return singletonUDPSender;
 }
 
+bool ACotPawn::GetShouldSendCoT_Implementation()
+{
+	return ShouldSendCoT;
+}
+
 void ACotPawn::SetType_Implementation(FString& NewType)
 {
 	Type = NewType;
@@ -146,4 +152,9 @@ void ACotPawn::SetLe_Implementation(float NewLe)
 void ACotPawn::SetUDPSender_Implementation(AUDPSender* UdpSender)
 {
 	singletonUDPSender = UdpSender;
+}
+
+void ACotPawn::SetShouldSendCoT_Implementation(bool NewShouldSendCoT)
+{
+	ShouldSendCoT = NewShouldSendCoT;
 }

--- a/Source/TAKGM/Private/UDP/UDPSender.cpp
+++ b/Source/TAKGM/Private/UDP/UDPSender.cpp
@@ -145,7 +145,7 @@ void AUDPSender::BroadcastCot(bool PrintToScreen, bool PrintToLog)
 	for (AActor* Actor : Actors) {
 		ICotSharable* CotSharableActor = Cast<ICotSharable>(Actor);
 		
-		if (ICotSharable::Execute_GetIsStale(Actor)) {
+		if (ICotSharable::Execute_GetIsStale(Actor) || ICotSharable::Execute_GetShouldSendCoT(Actor)) {
 			continue;
 		}
 

--- a/Source/TAKGM/Public/Cot/CotActor.h
+++ b/Source/TAKGM/Public/Cot/CotActor.h
@@ -47,6 +47,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cot Sharable")
 		bool isStale;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cot Sharable")
+		bool ShouldSendCoT;
+
 	// Constructor
 	ACotActor();
 
@@ -81,6 +84,8 @@ public:
 
 	virtual bool GetIsStale_Implementation() override;
 
+	virtual bool GetShouldSendCoT_Implementation() override;
+
 	virtual AUDPSender* GetUDPSender_Implementation() override;
 
 	virtual void SetType_Implementation(FString& NewType) override;
@@ -100,4 +105,6 @@ public:
 	virtual void SetLe_Implementation(float NewLe) override;
 
 	virtual void SetUDPSender_Implementation(AUDPSender* UdpSender) override;
+
+	virtual void SetShouldSendCoT_Implementation(bool NewShouldSendCoT) override;
 };

--- a/Source/TAKGM/Public/Cot/CotCharacter.h
+++ b/Source/TAKGM/Public/Cot/CotCharacter.h
@@ -47,6 +47,8 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cot Sharable")
 		AUDPSender* singletonUDPSender;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cot Sharable")
+		bool ShouldSendCoT;
 	// Constructor
 	ACotCharacter();
 
@@ -84,6 +86,8 @@ public:
 
 	virtual AUDPSender* GetUDPSender_Implementation() override;
 
+	virtual bool GetShouldSendCoT_Implementation() override;
+
 	virtual void SetType_Implementation(FString& NewType) override;
 
 	virtual void SetUid_Implementation(FString& NewUid) override;
@@ -101,4 +105,6 @@ public:
 	virtual void SetLe_Implementation(float NewLe) override;
 
 	virtual void SetUDPSender_Implementation(AUDPSender* UdpSender) override;
+
+	virtual void SetShouldSendCoT_Implementation(bool NewShouldSendCoT) override;
 };

--- a/Source/TAKGM/Public/Cot/CotPawn.h
+++ b/Source/TAKGM/Public/Cot/CotPawn.h
@@ -47,6 +47,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cot Sharable")
 		AUDPSender* singletonUDPSender;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cot Sharable")
+		bool ShouldSendCoT;
+
 	// Constructor
 	ACotPawn();
 
@@ -86,6 +89,8 @@ public:
 
 	virtual AUDPSender* GetUDPSender_Implementation() override;
 
+	virtual bool GetShouldSendCoT_Implementation() override;
+
 	virtual void SetType_Implementation(FString& NewType) override;
 
 	virtual void SetUid_Implementation(FString& NewUid) override;
@@ -103,4 +108,6 @@ public:
 	virtual void SetLe_Implementation(float NewLe) override;
 
 	virtual void SetUDPSender_Implementation(AUDPSender* UdpSender) override;
+
+	virtual void SetShouldSendCoT_Implementation(bool NewShouldSendCoT) override;
 };

--- a/Source/TAKGM/Public/Cot/CotSharable.h
+++ b/Source/TAKGM/Public/Cot/CotSharable.h
@@ -52,6 +52,9 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Cot Entity")
 		AUDPSender* GetUDPSender();
 
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Cot Entity")
+		bool GetShouldSendCoT();
+
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Cot Entity", meta = (AdvancedDisplay = 1))
 		void SetType(UPARAM(ref, DisplayName = "Type") FString& NewType);
 
@@ -79,5 +82,6 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Cot Entity")
 		void SetUDPSender(UPARAM(DisplayName = "UDP Sender Reference") AUDPSender* UdpSender);
 
-
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Cot Entity")
+		void SetShouldSendCoT(UPARAM(DisplayName = "Should Send CoT") bool shouldSendCoT);
 };


### PR DESCRIPTION
Expanded CotSharable interface to include methods for getting and setting ShouldSendCoT. Implemented by interfaces CotActor, CotCharacter, and CotPawn. The default value is true.